### PR TITLE
Update to Grunt-svgmin from 2.0.1 to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     {
       "name": "Thomas Nadin",
       "email": "thomas.nadin@epiphanysolutions.co.uk"
+    },
+    {
+      "name": "Alex Bennett",
+      "email": "alex.bennett@epiphanysolutions.co.uk"
     }
   ],
   "client": {
@@ -65,7 +69,7 @@
     "grunt-remove-logging": "^0.2.0",
     "grunt-sass": "^1.0.0",
     "grunt-shell": "^1.1.2",
-    "grunt-svgmin": "^2.0.1",
+    "grunt-svgmin": "^3.3.0",
     "jpegtran-bin": "0.2.0",
     "jshint-stylish": "^2.0.0",
     "jspm": "^0.16.11",


### PR DESCRIPTION
Main reason for this upgrade. 
Version two gave you a "parse error" if it encountered an SVG with unneeded internal markup. Now it flags which line/column it trips over to allow for easier debugging.
